### PR TITLE
fix: Use 127.0.0.1 to fix vite proxy error

### DIFF
--- a/packages/ui/core/proxy.conf.json
+++ b/packages/ui/core/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:3000",
+    "target": "http://127.0.0.1:3000",
     "secure": false,
     "changeOrigin": true,
     "pathRewrite": {


### PR DESCRIPTION
## What does this PR do?

Forces node to use ipv4 when proxying in dev mode. [node 17 and above prefers to resolve `localhost` as ipv6](https://github.com/nodejs/node/issues/40537). This causes vite proxy to fail because our backend server is bound to an ipv4 address. The error looks like this

```
[GUI] 4:43:19 PM [vite] http proxy error: /v1/flags
[GUI] Error: connect ECONNREFUSED ::1:3000
[GUI]     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1555:16)
```

Notice the `::1` address.

Fixes # (issue)

